### PR TITLE
Changed method definition from arhcive to archive in ContainerDSL

### DIFF
--- a/client/src/main/java/io/fabric8/docker/client/impl/ArchiveContainer.java
+++ b/client/src/main/java/io/fabric8/docker/client/impl/ArchiveContainer.java
@@ -24,11 +24,11 @@ import io.fabric8.docker.dsl.container.DownloadFromUploadToInterface;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-public class ArchieveContainer extends BaseContainerOperation  implements DownloadFromUploadToInterface<InputStream, OutputStream> {
+public class ArchiveContainer extends BaseContainerOperation  implements DownloadFromUploadToInterface<InputStream, OutputStream> {
 
     private static final String ARCHIVE = "archive";
 
-    public ArchieveContainer(OkHttpClient client, Config config, String name) {
+    public ArchiveContainer(OkHttpClient client, Config config, String name) {
         super(client, config, name, ARCHIVE);
     }
 

--- a/client/src/main/java/io/fabric8/docker/client/impl/ContainerNamedOperationImpl.java
+++ b/client/src/main/java/io/fabric8/docker/client/impl/ContainerNamedOperationImpl.java
@@ -32,7 +32,7 @@ import io.fabric8.docker.client.DockerClientException;
 import io.fabric8.docker.client.utils.URLUtils;
 import io.fabric8.docker.dsl.InputOutputErrorHandle;
 import io.fabric8.docker.dsl.OutputHandle;
-import io.fabric8.docker.dsl.container.ContainerExecResourceLogsAttachArhciveInterface;
+import io.fabric8.docker.dsl.container.ContainerExecResourceLogsAttachArchiveInterface;
 import io.fabric8.docker.dsl.container.ContainerInputOutputErrorStreamGetLogsInterface;
 import io.fabric8.docker.dsl.container.DownloadFromUploadToInterface;
 import io.fabric8.docker.dsl.container.SinceContainerOutputErrorTimestampsTailingLinesFollowDisplayInterface;
@@ -43,7 +43,7 @@ import java.net.URL;
 import java.util.List;
 
 public class ContainerNamedOperationImpl extends BaseContainerOperation implements
-        ContainerExecResourceLogsAttachArhciveInterface<ContainerExecCreateResponse, InlineExecConfig, ContainerProcessList, List<ContainerChange>, InputStream, Stats, Boolean, OutputHandle, ContainerInspect, InputOutputErrorHandle, OutputStream> {
+        ContainerExecResourceLogsAttachArchiveInterface<ContainerExecCreateResponse, InlineExecConfig, ContainerProcessList, List<ContainerChange>, InputStream, Stats, Boolean, OutputHandle, ContainerInspect, InputOutputErrorHandle, OutputStream> {
 
     private static final String EXEC_OPERATION = "exec";
     private static final String TOP_OPERATION = "top";
@@ -66,8 +66,8 @@ public class ContainerNamedOperationImpl extends BaseContainerOperation implemen
     }
 
     @Override
-    public DownloadFromUploadToInterface<InputStream, OutputStream> arhcive() {
-        return new ArchieveContainer(client, config, name);
+    public DownloadFromUploadToInterface<InputStream, OutputStream> archive() {
+        return new ArchiveContainer(client, config, name);
     }
 
     @Override

--- a/client/src/main/java/io/fabric8/docker/client/impl/ContainerOperationImpl.java
+++ b/client/src/main/java/io/fabric8/docker/client/impl/ContainerOperationImpl.java
@@ -32,7 +32,7 @@ import io.fabric8.docker.client.Config;
 import io.fabric8.docker.client.DockerClientException;
 import io.fabric8.docker.dsl.InputOutputErrorHandle;
 import io.fabric8.docker.dsl.OutputHandle;
-import io.fabric8.docker.dsl.container.ContainerExecResourceLogsAttachArhciveInterface;
+import io.fabric8.docker.dsl.container.ContainerExecResourceLogsAttachArchiveInterface;
 import io.fabric8.docker.dsl.container.ContainerInterface;
 import io.fabric8.docker.dsl.container.LimitSinceBeforeSizeFiltersAllRunningInterface;
 
@@ -56,7 +56,7 @@ public class ContainerOperationImpl extends BaseContainerOperation implements Co
     }
 
     @Override
-    public ContainerExecResourceLogsAttachArhciveInterface<ContainerExecCreateResponse, InlineExecConfig, ContainerProcessList, List<ContainerChange>, InputStream, Stats, Boolean, OutputHandle, ContainerInspect, InputOutputErrorHandle, OutputStream> withName(String name) {
+    public ContainerExecResourceLogsAttachArchiveInterface<ContainerExecCreateResponse, InlineExecConfig, ContainerProcessList, List<ContainerChange>, InputStream, Stats, Boolean, OutputHandle, ContainerInspect, InputOutputErrorHandle, OutputStream> withName(String name) {
         return new ContainerNamedOperationImpl(client, config, name);
     }
 

--- a/dsl/src/main/java/io/fabric8/docker/dsl/container/ContainerDSL.java
+++ b/dsl/src/main/java/io/fabric8/docker/dsl/container/ContainerDSL.java
@@ -299,7 +299,7 @@ public interface ContainerDSL {
 
     @ArchiveOption
     @All({NamedOption.class})
-    void arhcive();
+    void archive();
 
     @Terminal
     @All({ArchiveOption.class})


### PR DESCRIPTION
Changes proposed in this PR
* Renamed method from `arhcive` to `archive` in ContainerDSL.
* Renamed class from `ArchieveContainer` to `ArchiveContainer`