### PR TITLE
Exposed datastream of logs using eventlistener

### DIFF
--- a/client/src/main/java/io/fabric8/docker/client/DefaultDockerClient.java
+++ b/client/src/main/java/io/fabric8/docker/client/DefaultDockerClient.java
@@ -88,7 +88,7 @@ public class DefaultDockerClient implements DockerClient {
     @Override
     public Boolean ping() {
         try {
-             new OperationSupport(client, configuration, "_ping", null, null).handleGet();
+            new OperationSupport(client, configuration, "_ping", null, null).handleGet();
             return true;
         } catch (Exception e) {
             return false;
@@ -107,7 +107,7 @@ public class DefaultDockerClient implements DockerClient {
 
     @Override
     public ExecInterface exec() {
-        return new ExecOperationImpl(client,configuration, "exec");//TODO: check this
+        return new ExecOperationImpl(client, configuration, "exec");//TODO: check this
     }
 
     @Override
@@ -131,11 +131,9 @@ public class DefaultDockerClient implements DockerClient {
             client.connectionPool().evictAll();
         }
         if (client.dispatcher() != null &&
-                client.dispatcher().executorService() != null &&
-                !client.dispatcher().executorService().isShutdown()
-                ) {
-            client
-                    .dispatcher().executorService().shutdown();
+            client.dispatcher().executorService() != null &&
+            !client.dispatcher().executorService().isShutdown()) {
+            client.dispatcher().executorService().shutdown();
         }
     }
 }

--- a/client/src/main/java/io/fabric8/docker/client/DockerStreamData.java
+++ b/client/src/main/java/io/fabric8/docker/client/DockerStreamData.java
@@ -1,43 +1,23 @@
 package io.fabric8.docker.client;
 
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Map;
-
 public interface DockerStreamData {
 
-  StreamType streamType();
+    StreamType streamType();
 
-  int size();
+    int size();
 
-  byte[] payload();
+    byte[] payload();
 
-  enum StreamType {
-    STDIN(0),
-    STDOUT(1),
-    STDERR(2);
+    enum StreamType {
+        STDIN(0),
+        STDOUT(1),
+        STDERR(2),
+        RAW(3);
 
-    private static final Map<Integer, StreamType> lookup = new HashMap<>(3);
+        private final int value;
 
-    static {
-      for(StreamType s : EnumSet.allOf(StreamType.class)) {
-        lookup.put(s.value, s);
-      }
+        StreamType(int streamType) {
+            this.value = streamType;
+        }
     }
-
-    private final int value;
-
-    StreamType(int streamType) {
-      this.value = streamType;
-    }
-
-    public static StreamType lookup(int streamType) {
-      StreamType type = lookup.get(streamType);
-      if (type == null) {
-        throw new IllegalArgumentException("Invalid stream type value: " + streamType);
-      }
-      return type;
-    }
-  }
-
 }

--- a/client/src/main/java/io/fabric8/docker/client/DockerStreamDataImpl.java
+++ b/client/src/main/java/io/fabric8/docker/client/DockerStreamDataImpl.java
@@ -1,0 +1,42 @@
+package io.fabric8.docker.client;
+
+public class DockerStreamDataImpl implements DockerStreamData {
+
+    private StreamType type;
+
+    private int size;
+
+    private byte[] payload;
+
+    public DockerStreamDataImpl(StreamType type, int size, byte[] payload) {
+        this.type = type;
+        this.size = size;
+        this.payload = payload;
+    }
+
+    public DockerStreamDataImpl(StreamType type, byte[] payload) {
+        this.type = type;
+        this.payload = payload;
+    }
+
+    @Override
+    public StreamType streamType() {
+        return type;
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public byte[] payload() {
+        return payload;
+    }
+
+    @Override
+    public String toString() {
+        return new String(payload).trim();
+    }
+}
+

--- a/client/src/main/java/io/fabric8/docker/client/DockerStreamDataReader.java
+++ b/client/src/main/java/io/fabric8/docker/client/DockerStreamDataReader.java
@@ -1,0 +1,99 @@
+package io.fabric8.docker.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import javax.validation.constraints.NotNull;
+
+import static io.fabric8.docker.client.DockerStreamData.StreamType.RAW;
+import static io.fabric8.docker.client.DockerStreamData.StreamType.STDERR;
+import static io.fabric8.docker.client.DockerStreamData.StreamType.STDIN;
+import static io.fabric8.docker.client.DockerStreamData.StreamType.STDOUT;
+
+public class DockerStreamDataReader implements AutoCloseable {
+
+    private static final int HEADER_SIZE = 8;
+
+    private final byte[] rawBuffer = new byte[1000];
+
+    private final InputStream inputStream;
+
+    private Boolean rawStreamDetected = false;
+
+    public DockerStreamDataReader(InputStream inputStream) {
+        this.inputStream = inputStream;
+    }
+
+    private static DockerStreamData.StreamType streamType(byte streamType) {
+        switch (streamType) {
+            case 0:
+                return STDIN;
+            case 1:
+                return STDOUT;
+            case 2:
+                return STDERR;
+            default:
+                return RAW;
+        }
+    }
+
+    @NotNull
+    public DockerStreamDataImpl readStreamData() throws IOException {
+
+        if (rawStreamDetected) {
+            int read = inputStream.read(rawBuffer);
+            if (read == -1) {
+                return null;
+            }
+
+            return new DockerStreamDataImpl(RAW, Arrays.copyOf(rawBuffer, read));
+        } else {
+
+            byte[] header = new byte[HEADER_SIZE];
+
+            int actualHeaderSize = 0;
+
+            do {
+                int headerCount = inputStream.read(header, actualHeaderSize, HEADER_SIZE - actualHeaderSize);
+
+                if (headerCount == -1) {
+                    return null;
+                }
+                actualHeaderSize += headerCount;
+            } while (actualHeaderSize < HEADER_SIZE);
+
+            DockerStreamData.StreamType streamType = streamType(header[0]);
+
+            if (streamType.equals(RAW)) {
+                rawStreamDetected = true;
+                return new DockerStreamDataImpl(RAW, Arrays.copyOf(header, HEADER_SIZE));
+            }
+
+            int payloadSize = ((header[4] & 0xff) << 24) + ((header[5] & 0xff) << 16) + ((header[6] & 0xff) << 8)
+                + (header[7] & 0xff);
+
+            byte[] payload = new byte[payloadSize];
+            int actualPayloadSize = 0;
+
+            do {
+                int count = inputStream.read(payload, actualPayloadSize, payloadSize - actualPayloadSize);
+
+                if (count == -1) {
+                    if (actualPayloadSize != payloadSize) {
+                        throw new IOException(String.format("payload must be %d bytes long, but was %d", payloadSize,
+                            actualPayloadSize));
+                    }
+                    break;
+                }
+                actualPayloadSize += count;
+            } while (actualPayloadSize < payloadSize);
+
+            return new DockerStreamDataImpl(streamType, payload);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        inputStream.close();
+    }
+}

--- a/client/src/main/java/io/fabric8/docker/client/impl/ContainerLogHandle.java
+++ b/client/src/main/java/io/fabric8/docker/client/impl/ContainerLogHandle.java
@@ -1,147 +1,155 @@
-/*
- * Copyright (C) 2016 Original Authors
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
 package io.fabric8.docker.client.impl;
 
-import okhttp3.Call;
-import okhttp3.Callback;
-import okhttp3.Request;
-import okhttp3.Response;
 import io.fabric8.docker.client.DockerClientException;
 import io.fabric8.docker.client.DockerStreamData;
 import io.fabric8.docker.client.utils.DockerStreamPumper;
+import io.fabric8.docker.dsl.EventListener;
 import io.fabric8.docker.dsl.OutputErrorHandle;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
-import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class ContainerLogHandle implements OutputErrorHandle, Callback {
+public class ContainerLogHandle implements Callback, OutputErrorHandle {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ContainerLogHandle.class);
 
     private final OutputStream out;
     private final OutputStream err;
 
-    private final PipedInputStream output;
-    private final PipedInputStream error;
-    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final PipedInputStream pipedOutput;
+    private final PipedInputStream pipedError;
+    private final EventListener listener;
 
-    protected final ArrayBlockingQueue<Object> queue = new ArrayBlockingQueue<>(1);
+    private final AtomicReference<Response> response = new AtomicReference<>();
+    private final AtomicReference<Throwable> error = new AtomicReference<>();
+
     private final ExecutorService executorService = Executors.newSingleThreadExecutor();
     private DockerStreamPumper pumper;
+    private final AtomicBoolean succeded = new AtomicBoolean(false);
+    private final AtomicBoolean failed = new AtomicBoolean(false);
 
-    public ContainerLogHandle(OutputStream out, OutputStream err, PipedInputStream outputPipe, PipedInputStream errorPipe) {
+    private final CountDownLatch latch = new CountDownLatch(1);
+
+    public ContainerLogHandle(OutputStream out, OutputStream err, PipedInputStream outputPipe,
+        PipedInputStream errorPipe) {
+        this(out, err, outputPipe, errorPipe, OperationSupport.NULL_LISTENER);
+    }
+
+    public ContainerLogHandle(OutputStream out, OutputStream err, PipedInputStream outputPipe, PipedInputStream errorPipe,
+        EventListener listener) {
+
         this.out = outputStreamOrPipe(out, outputPipe);
         this.err = outputStreamOrPipe(err, errorPipe);
 
-        this.output = outputPipe;
-        this.error = errorPipe;
+        this.pipedOutput = outputPipe;
+        this.pipedError = errorPipe;
+
+        this.listener = listener;
     }
 
     @Override
-    public void close() {
-        executorService.shutdown();
-
-        try {
-            if (executorService.awaitTermination(3, TimeUnit.SECONDS)) {
-                executorService.shutdownNow();
-            }
-        } catch (Throwable t) {
-            throw DockerClientException.launderThrowable(t);
-        }
-    }
-
-    public void waitUntilReady() {
-        try {
-            Object obj = queue.poll(10, TimeUnit.SECONDS);
-            if (obj instanceof Boolean && ((Boolean) obj)) {
-                return;
-            } else {
-                if (obj instanceof Throwable) {
-                    throw (Throwable) obj;
-                }
-            }
-        } catch (Throwable t) {
-            throw DockerClientException.launderThrowable(t);
-        }
-    }
-    @Override
-    public void onFailure(Call call, IOException ioe) {
-        LOGGER.error("Request Failure.", ioe);
-        //We only need to queue startup failures.
-        if (!started.get()) {
-            queue.add(ioe);
-        }
+    public void onFailure(Call call, IOException e) {
+        error.set(e);
+        listener.onError(e.getMessage());
+        latch.countDown();
     }
 
     @Override
-    public void onResponse(Call call, Response response) throws IOException {
-        if (out instanceof PipedOutputStream && output != null) {
-            output.connect((PipedOutputStream) out);
+    public void onResponse(Call call, Response r) throws IOException {
+        response.set(r);
+
+        if (out instanceof PipedOutputStream && pipedOutput != null) {
+            pipedOutput.connect((PipedOutputStream) out);
         }
 
-        pumper = new DockerStreamPumper(response.body().source(), new io.fabric8.docker.api.model.Callback<DockerStreamData, Void>() {
-
-            @Override
-            public Void call(DockerStreamData input) {
-                try {
-                    switch (input.streamType()) {
-                        case STDIN:
-                        case STDOUT:
-                            if (out != null) {
-                                out.write(input.payload());
-                            }
-                            break;
-                        case STDERR:
-                            if (err != null) {
-                                err.write(input.payload());
-                            }
-                            break;
-                        default:
-                            throw new IOException("Unknown stream ID " + input.streamType());
+        pumper =
+            new DockerStreamPumper(r.body().source(),
+                new io.fabric8.docker.api.model.Callback<DockerStreamData, Void>() {
+                    @Override
+                    public Void call(DockerStreamData input) {
+                        processStream(input);
+                        writeSteam(input);
+                        return null;
                     }
-                } catch (IOException e) {
-                    throw DockerClientException.launderThrowable(e);
+                }, new io.fabric8.docker.api.model.Callback<Boolean, Void>() {
+                @Override
+                public Void call(Boolean success) {
+                    if (success) {
+                        if (succeded.compareAndSet(false, true) && !failed.get()) {
+                            listener.onSuccess("Done.");
+                        }
+                    } else {
+                        if (failed.compareAndSet(false, true)) {
+                            listener.onError("Failed.");
+                        }
+                    }
+                    return null;
                 }
-                return null;
-            }
-        });
+            });
         executorService.submit(pumper);
-        started.set(true);
-        queue.add(true);
+        latch.countDown();
     }
 
-
-    public InputStream getOutput() {
-        return output;
+    private void writeSteam(DockerStreamData input) {
+        if (input != null) {
+            try {
+                switch (input.streamType()) {
+                    case STDOUT:
+                    case RAW:
+                        if (out != null) {
+                            out.write(input.payload());
+                            out.flush();
+                        }
+                        break;
+                    case STDERR:
+                        if (err != null) {
+                            err.write(input.payload());
+                            err.flush();
+                        }
+                        break;
+                    default:
+                        LOGGER.error("unknown stream type:" + input.streamType());
+                }
+            } catch (IOException e) {
+                throw DockerClientException.launderThrowable(e);
+            }
+            LOGGER.debug(input.toString());
+        }
     }
 
-    public InputStream getError() {
-        return error;
+    private void processStream(DockerStreamData input) {
+        if (input == null) {
+            // ignore
+        } else if (isFailure(input) && failed.compareAndSet(false, true)) {
+            listener.onError("");
+        } else {
+            if (isSuccess(input) && succeded.compareAndSet(false, true)) {
+                listener.onSuccess(input.toString());
+            } else {
+                listener.onEvent(input.toString());
+            }
+        }
+    }
+
+    private boolean isSuccess(DockerStreamData input) {
+        return false;
+    }
+
+    private boolean isFailure(DockerStreamData input) {
+        return false;
     }
 
     private static OutputStream outputStreamOrPipe(OutputStream stream, PipedInputStream in) {
@@ -154,5 +162,36 @@ public class ContainerLogHandle implements OutputErrorHandle, Callback {
         }
     }
 
+    @Override
+    public void close() throws IOException {
+        pumper.close();
+        executorService.shutdown();
 
+        try {
+            if (executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+                executorService.shutdownNow();
+            }
+        } catch (Throwable t) {
+            throw DockerClientException.launderThrowable(t);
+        }
+
+        Response r = response.get();
+        if (r != null) {
+            try {
+                r.body().close();
+            } catch (Throwable t) {
+                LOGGER.warn("Error while closing response stream:" + t.getMessage());
+            }
+        }
+    }
+
+    @Override
+    public InputStream getError() {
+        return pipedError;
+    }
+
+    @Override
+    public InputStream getOutput() {
+        return pipedOutput;
+    }
 }

--- a/client/src/main/java/io/fabric8/docker/client/impl/ContainerNamedOperationImpl.java
+++ b/client/src/main/java/io/fabric8/docker/client/impl/ContainerNamedOperationImpl.java
@@ -17,9 +17,6 @@
 
 package io.fabric8.docker.client.impl;
 
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
 import io.fabric8.docker.api.model.ContainerChange;
 import io.fabric8.docker.api.model.ContainerExecCreateResponse;
 import io.fabric8.docker.api.model.ContainerInspect;
@@ -35,12 +32,14 @@ import io.fabric8.docker.dsl.OutputHandle;
 import io.fabric8.docker.dsl.container.ContainerExecResourceLogsAttachArchiveInterface;
 import io.fabric8.docker.dsl.container.ContainerInputOutputErrorStreamGetLogsInterface;
 import io.fabric8.docker.dsl.container.DownloadFromUploadToInterface;
-import io.fabric8.docker.dsl.container.SinceContainerOutputErrorTimestampsTailingLinesFollowDisplayInterface;
-
+import io.fabric8.docker.dsl.container.SinceContainerOutputErrorTimestampsTailingLinesUsingListenerFollowDisplayInterface;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.util.List;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
 
 public class ContainerNamedOperationImpl extends BaseContainerOperation implements
         ContainerExecResourceLogsAttachArchiveInterface<ContainerExecCreateResponse, InlineExecConfig, ContainerProcessList, List<ContainerChange>, InputStream, Stats, Boolean, OutputHandle, ContainerInspect, InputOutputErrorHandle, OutputStream> {
@@ -256,7 +255,7 @@ public class ContainerNamedOperationImpl extends BaseContainerOperation implemen
     }
 
     @Override
-    public SinceContainerOutputErrorTimestampsTailingLinesFollowDisplayInterface<OutputHandle> logs() {
+    public SinceContainerOutputErrorTimestampsTailingLinesUsingListenerFollowDisplayInterface<OutputHandle> logs() {
         return new GetLogsOfContainer(client, config, name, null, null, null, null, null, 0, false);
     }
 

--- a/dsl/src/main/java/io/fabric8/docker/dsl/container/ContainerDSL.java
+++ b/dsl/src/main/java/io/fabric8/docker/dsl/container/ContainerDSL.java
@@ -28,6 +28,7 @@ import io.fabric8.docker.api.model.ExecConfig;
 import io.fabric8.docker.api.model.InlineContainerCreate;
 import io.fabric8.docker.api.model.InlineExecConfig;
 import io.fabric8.docker.api.model.Stats;
+import io.fabric8.docker.dsl.EventListener;
 import io.fabric8.docker.dsl.InputOutputErrorHandle;
 import io.fabric8.docker.dsl.OutputHandle;
 import io.fabric8.docker.dsl.annotations.CreateOption;
@@ -272,6 +273,9 @@ public interface ContainerDSL {
 
     @All({LogOption.class})
     void tailingLines(int number);
+
+    @All({LogOption.class})
+    void usingListener(EventListener listener);
 
     @Terminal
     @All(NamedOption.class)


### PR DESCRIPTION
Changes proposed in this PR
* Added `usingEventListener` method 
* Exposed Docker stream payload using eventListener, so user can implement different awaitStrategy for container to up.
* Modifed `StreamReader` logic to not get `EOFException`