### PR TITLE
Removed dependency on commons-codec

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -56,10 +56,6 @@
             <artifactId>commons-compress</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>${okhttp.version}</version>

--- a/client/src/main/java/io/fabric8/docker/client/Config.java
+++ b/client/src/main/java/io/fabric8/docker/client/Config.java
@@ -28,7 +28,6 @@ import io.fabric8.docker.client.utils.URLUtils;
 import io.fabric8.docker.client.utils.Utils;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.Inline;
-import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,6 +39,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.xml.bind.DatatypeConverter;
 
 import static io.fabric8.docker.client.utils.Utils.getSystemPropertyOrEnvVar;
 import static io.fabric8.docker.client.utils.Utils.hasSystemPropertyOrEnvVar;
@@ -225,8 +225,7 @@ public class Config {
                         String serverAddress = entry.getKey();
                         AuthConfig authConfig = entry.getValue();
                         if (authConfig.getAuth() != null) {
-                            String auth = new String(Base64.decodeBase64(authConfig.getAuth().getBytes(UTF_8)), UTF_8);
-                            Matcher m = AUTH_PATTERN.matcher(auth);
+                            Matcher m = AUTH_PATTERN.matcher(DatatypeConverter.printBase64Binary(authConfig.getAuth().getBytes(UTF_8)));
                             if (m.matches()) {
                                 String username = m.group(USERNAME_LABEL);
                                 String password = m.group(PASSWORD_LABEL);

--- a/client/src/main/java/io/fabric8/docker/client/impl/BuildImage.java
+++ b/client/src/main/java/io/fabric8/docker/client/impl/BuildImage.java
@@ -55,10 +55,10 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import javax.xml.bind.DatatypeConverter;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 
@@ -261,7 +261,7 @@ public class BuildImage extends BaseImageOperation implements
 
             RequestBody body = RequestBody.create(MEDIA_TYPE_TAR, new File(path));
             Request request = new Request.Builder()
-                    .header("X-Registry-Config", new String(Base64.encodeBase64(JSON_MAPPER.writeValueAsString(config.getAuthConfigs()).getBytes("UTF-8")), "UTF-8"))
+                    .header("X-Registry-Config", DatatypeConverter.printBase64Binary(JSON_MAPPER.writeValueAsString(config.getAuthConfigs()).getBytes("UTF-8")))
                     .post(body)
                     .url(sb.toString()).build();
 

--- a/client/src/main/java/io/fabric8/docker/client/impl/ImportImage.java
+++ b/client/src/main/java/io/fabric8/docker/client/impl/ImportImage.java
@@ -31,11 +31,11 @@ import io.fabric8.docker.dsl.image.AsRepoInterface;
 import io.fabric8.docker.dsl.image.RedirectingWritingOutputTagAsRepoInterface;
 import io.fabric8.docker.dsl.image.TagAsRepoInterface;
 import io.fabric8.docker.dsl.image.UsingListenerRedirectingWritingOutputTagAsRepoInterface;
-import org.apache.commons.codec.binary.Base64;
 
 import java.io.OutputStream;
 import java.io.PipedOutputStream;
 import java.util.concurrent.TimeUnit;
+import javax.xml.bind.DatatypeConverter;
 
 public class ImportImage extends BaseImageOperation implements
         UsingListenerRedirectingWritingOutputTagAsRepoInterface<OutputHandle>,
@@ -72,7 +72,7 @@ public class ImportImage extends BaseImageOperation implements
             }
             AuthConfig authConfig = RegistryUtils.getConfigForImage(name, config);
             Request request = new Request.Builder()
-                    .header("X-Registry-Auth", new String(Base64.encodeBase64(JSON_MAPPER.writeValueAsString(authConfig != null ? authConfig : new AuthConfig()).getBytes("UTF-8")), "UTF-8"))
+                    .header("X-Registry-Auth", DatatypeConverter.printBase64Binary(JSON_MAPPER.writeValueAsString(authConfig != null ? authConfig : new AuthConfig()).getBytes("UTF-8")))
                     .post(RequestBody.create(MEDIA_TYPE_TEXT, EMPTY))
                     .url(sb.toString()).build();
 

--- a/client/src/main/java/io/fabric8/docker/client/impl/PullImage.java
+++ b/client/src/main/java/io/fabric8/docker/client/impl/PullImage.java
@@ -31,11 +31,11 @@ import io.fabric8.docker.dsl.image.FromRegistryInterface;
 import io.fabric8.docker.dsl.image.RedirectingWritingOutputTagFromRegistryInterface;
 import io.fabric8.docker.dsl.image.TagFromRegistryInterface;
 import io.fabric8.docker.dsl.image.UsingListenerRedirectingWritingOutputTagFromRegistryInterface;
-import org.apache.commons.codec.binary.Base64;
 
 import java.io.OutputStream;
 import java.io.PipedOutputStream;
 import java.util.concurrent.TimeUnit;
+import javax.xml.bind.DatatypeConverter;
 
 public class PullImage extends BaseImageOperation implements
         UsingListenerRedirectingWritingOutputTagFromRegistryInterface<OutputHandle>,
@@ -96,7 +96,7 @@ public class PullImage extends BaseImageOperation implements
 
             AuthConfig authConfig = RegistryUtils.getConfigForImage(name, config);
             Request request = new Request.Builder()
-                    .header("X-Registry-Auth", new String(Base64.encodeBase64(JSON_MAPPER.writeValueAsString(authConfig != null ? authConfig : new AuthConfig()).getBytes("UTF-8")), "UTF-8"))
+                    .header("X-Registry-Auth", DatatypeConverter.printBase64Binary(JSON_MAPPER.writeValueAsString(authConfig != null ? authConfig : new AuthConfig()).getBytes("UTF-8")))
                     .post(RequestBody.create(MEDIA_TYPE_TEXT, EMPTY))
                     .url(sb.toString()).build();
 

--- a/client/src/main/java/io/fabric8/docker/client/impl/PushImage.java
+++ b/client/src/main/java/io/fabric8/docker/client/impl/PushImage.java
@@ -32,11 +32,11 @@ import io.fabric8.docker.dsl.image.RedirectingWritingOutputTagForceToRegistryInt
 import io.fabric8.docker.dsl.image.TagForceToRegistryInterface;
 import io.fabric8.docker.dsl.image.ToRegistryInterface;
 import io.fabric8.docker.dsl.image.UsingListenerRedirectingWritingOutputTagForceToRegistryInterface;
-import org.apache.commons.codec.binary.Base64;
 
 import java.io.OutputStream;
 import java.io.PipedOutputStream;
 import java.util.concurrent.TimeUnit;
+import javax.xml.bind.DatatypeConverter;
 
 public class PushImage extends BaseImageOperation implements
         UsingListenerRedirectingWritingOutputTagForceToRegistryInterface<OutputHandle>,
@@ -77,7 +77,7 @@ public class PushImage extends BaseImageOperation implements
             AuthConfig authConfig = RegistryUtils.getConfigForImage(name, config);
             RequestBody body = RequestBody.create(MEDIA_TYPE_JSON, "{}");
             Request request = new Request.Builder()
-                    .header("X-Registry-Auth", new String(Base64.encodeBase64(JSON_MAPPER.writeValueAsString(authConfig != null ? authConfig : new AuthConfig()).getBytes("UTF-8")), "UTF-8"))
+                    .header("X-Registry-Auth", DatatypeConverter.printBase64Binary(JSON_MAPPER.writeValueAsString(authConfig != null ? authConfig : new AuthConfig()).getBytes("UTF-8")))
                     .post(body)
                     .url(sb.toString()).build();
 

--- a/platforms/karaf/features/src/main/resources/feature.xml
+++ b/platforms/karaf/features/src/main/resources/feature.xml
@@ -25,7 +25,6 @@
         <bundle dependency='true'>mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${jackson.version}</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${jackson.version}</bundle>
         <bundle dependency='true'>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${jackson.version}</bundle>
-        <bundle dependency="true">mvn:commons-codec/commons-codec/${commons-codec.version}</bundle>
         <bundle dependency="true">mvn:org.apache.commons/commons-compress/${commons-compress.version}</bundle>
         <bundle dependency="true">mvn:org.ow2.asm/asm/${asm.version}</bundle>
         <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.okio/${okio.bundle.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <commons-codec.version>1.10</commons-codec.version>
         <commons-compress.version>1.9</commons-compress.version>
         <easymock.version>3.2</easymock.version>
         <felix.scr.annotations.version>1.9.8</felix.scr.annotations.version>
@@ -144,11 +143,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>${commons-codec.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>


### PR DESCRIPTION
Hello; thanks for a great project!

This pull request removes the commons-codec dependency, which was used solely for its `Base64` class, in favor of the JDK's built in `javax.xml.bind.DatatypeConverter#printBase64Binary` method.  `mvn clean install` runs fine across the whole project.

I hope this is a useful contribution and that I've done it right! 😄 